### PR TITLE
Add single-player tooling and docs

### DIFF
--- a/core/Dockerfile.singleplayer
+++ b/core/Dockerfile.singleplayer
@@ -1,0 +1,12 @@
+FROM node:24-slim
+WORKDIR /usr/src/app
+
+# Install dependencies and build the client
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build-prod
+
+# Serve the static build (port 8080 inside container)
+EXPOSE 8080
+CMD ["npx", "serve", "-s", "static", "-l", "8080"]

--- a/core/README.md
+++ b/core/README.md
@@ -55,6 +55,32 @@ See LICENSE file for more details.
    npm i
    ```
 
+## 🕹️ Single Player
+
+Run the game entirely in your browser without starting the server.
+
+### Via npm script
+
+```bash
+npm run singleplayer
+```
+
+This launches the client-only development server and opens the game in your browser.
+
+### Via Docker
+
+Build the lightweight client image:
+
+```bash
+docker build -f Dockerfile.singleplayer -t openfront-sp .
+```
+
+Run it and open <http://localhost:8080>:
+
+```bash
+docker run --rm -p 8080:8080 openfront-sp
+```
+
 ## 🎮 Running the Game
 
 ### Development Mode

--- a/core/package.json
+++ b/core/package.json
@@ -4,6 +4,7 @@
     "build-dev": "webpack --config webpack.config.js --mode development",
     "build-prod": "webpack --config webpack.config.js --mode production",
     "start:client": "webpack serve --open --node-env development",
+    "singleplayer": "webpack serve --open --mode development --env singleplayer",
     "start:server": "node --loader ts-node/esm --experimental-specifier-resolution=node src/server/Server.ts",
     "start:server-dev": "cross-env GAME_ENV=dev node --loader ts-node/esm --experimental-specifier-resolution=node src/server/Server.ts",
     "dev": "cross-env GAME_ENV=dev concurrently \"npm run start:client\" \"npm run start:server-dev\"",


### PR DESCRIPTION
## Summary
- add `singleplayer` npm script for local client-only gameplay
- document single-player workflow and docker image
- introduce `Dockerfile.singleplayer` for lightweight client build

## Testing
- `npm test`
- `npm run lint` *(fails: 155 problems, 65 errors, 90 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b39901651c8325b468df8026bd589b